### PR TITLE
add -c option to localize based on an ssh user's current location

### DIFF
--- a/geocode/geocode.go
+++ b/geocode/geocode.go
@@ -171,6 +171,23 @@ func Autolocate() (geocode Geocode, err error) {
 	return geocode, nil
 }
 
+// Iplocate gets the requesters geocode response based off an IP address.
+func Iplocate(ip string) (geocode Geocode, err error) {
+	// send the request
+	resp, err := http.Get(fmt.Sprintf("%s/%s", geoipURI, ip))
+	if err != nil {
+		return geocode, err
+	}
+	defer resp.Body.Close()
+
+	// decode the body
+	dec := json.NewDecoder(resp.Body)
+	if err := dec.Decode(&geocode); err != nil {
+		return geocode, fmt.Errorf("Decoding autolocate response failed: %v", err)
+	}
+
+	return geocode, nil
+}
 // Locate gets the geocode data of a location that is passed as a string.
 func Locate(location, server string) (geocode Geocode, err error) {
 	// create json data


### PR DESCRIPTION
I wanted a way to snag my current location even if the machine is in a datacentre in New York (which it is), so it grabs $SSH_CONNECTION and pulls the remote IP out, passing that to GeoIP.

I'm not a Go programmer, this is the first piece of it I've written. Forgive (and critique :) ) the janky Go