### PR TITLE
Allow forecast for a single day

### DIFF
--- a/main.go
+++ b/main.go
@@ -109,7 +109,7 @@ func main() {
 		printError(err)
 	}
 
-	if days > 1 {
+	if days > 0 {
 		forecast.PrintDaily(fc, days)
 	}
 }


### PR DESCRIPTION
As it stands the minimum number of days you can get a forecast for is 2.