### PR TITLE
Adjusts humidity and cloud cover output - default width, precision 2

### DIFF
--- a/forecast/print.go
+++ b/forecast/print.go
@@ -148,7 +148,7 @@ func getBearingDetails(degrees float64) string {
 
 func printCommon(weather Weather, unitsFormat UnitMeasures) error {
 	if weather.Humidity > 0 {
-		humidity := colorstring.Color(fmt.Sprintf("[white]%v%s", weather.Humidity*100, "%"))
+		humidity := colorstring.Color(fmt.Sprintf("[white]%.2f%s", weather.Humidity*100, "%"))
 		if weather.Humidity > 0.20 {
 			fmt.Printf("  Ick! The humidity is %s\n", humidity)
 		} else {
@@ -177,7 +177,7 @@ func printCommon(weather Weather, unitsFormat UnitMeasures) error {
 	}
 
 	if weather.CloudCover > 0 {
-		cloudCover := colorstring.Color(fmt.Sprintf("[white]%v%s", weather.CloudCover*100, "%"))
+		cloudCover := colorstring.Color(fmt.Sprintf("[white]%.2f%s", weather.CloudCover*100, "%"))
 		fmt.Printf("  The cloud coverage is %s\n", cloudCover)
 	}
 


### PR DESCRIPTION
The current report is printing a ton of decimal places for humidity and cloud coverage which seems unnecessary. I've adjusted the formatting for those two numbers to use `%.2f` instead.

*Before:*

```
Current weather is Clear in Cape Town in Western Cape for January 24 at 1:48pm SAST
The temperature is 24.37°C

  Ick! The humidity is 57.99999999999999%
  The wind speed is 8.79 m/s S
  The cloud coverage is 7.000000000000001%
  The pressure is 1014.1 mbar

Clear throughout the day.

Rain chance:          ▁▁ ▁▁ ▁▁ ▁▁ ▁▁ ▁▁ ▁▁
             1p          5p          9p          1a
```

*After:*

```
Current weather is Clear in Cape Town in Western Cape for January 24 at 1:52pm SAST
The temperature is 24.4°C, but it feels like 24.41°C

  Ick! The humidity is 58.00%
  The wind speed is 8.83 m/s S
  The cloud coverage is 6%
  The pressure is 1014.09 mbar

Clear throughout the day.

Rain chance:          ▁▁ ▁▁ ▁▁ ▁▁ ▁▁ ▁▁ ▁▁
             1p          5p          9p          1a
```